### PR TITLE
Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ".": {
       "require": "./dist/index.js",
       "import": "./dist-esm/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",


### PR DESCRIPTION
Avoids warning error when used in other projects:
"[rollup-plugin-svelte] The following packages did
not export their `package.json` file so we could not check the
"svelte" field. If you had difficulties importing svelte components
from a package, then please contact the author and ask them to
export the package.json file."
